### PR TITLE
Fix CPU cleanup loop

### DIFF
--- a/utils/kernel.c
+++ b/utils/kernel.c
@@ -587,10 +587,10 @@ int start_kernel_tracing(struct uftrace_kernel_writer *kernel)
 	return 0;
 
 out:
-	for (i = 0; kernel->nr_cpus; i++) {
-		close(kernel->traces[i]);
-		close(kernel->fds[i]);
-	}
+        for (i = 0; i < kernel->nr_cpus; i++) {
+                close(kernel->traces[i]);
+                close(kernel->fds[i]);
+        }
 
 	free(kernel->traces);
 	free(kernel->fds);


### PR DESCRIPTION
## Summary
- fix cleanup loop in utils/kernel.c when kernel tracing startup fails

## Testing
- `./configure`
- `make unittest -j5`
- `make test` *(fails: file open failed / interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6842ae81ae588321ac5ab630307244f4