### PR TITLE
Use shutil.which in compiler detection

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -5,6 +5,7 @@ import multiprocessing
 import os
 import random
 import re
+import shutil
 import socket
 import subprocess as sp
 import sys
@@ -1022,8 +1023,7 @@ if __name__ == "__main__":
             flags[i] += '=%d' % patch_size[m]
 
     def has_compiler(compiler):
-        installed = os.system('command -v %s > /dev/null' % compiler) == 0
-        return installed
+        return shutil.which(compiler) is not None
 
     compilers = []
     if arg.python:


### PR DESCRIPTION
## Summary
- check compilers in tests using `shutil.which`

## Testing
- `python3 -m py_compile tests/runtest.py`
- `isort tests/runtest.py --check-only`

------
https://chatgpt.com/codex/tasks/task_e_6842b0fa457c83219973380820c7b8ef